### PR TITLE
Introduce aws-powertools logger & replace Axios with fetch

### DIFF
--- a/__tests__/createItem/function.int.mjs
+++ b/__tests__/createItem/function.int.mjs
@@ -1,6 +1,4 @@
-import axios from 'axios'
-
-axios.defaults.baseURL = `https://${process.env.httpApiGatewayEndpointId}.execute-api.${process.env.region}.amazonaws.com`
+const baseURL = `https://${process.env.httpApiGatewayEndpointId}.execute-api.${process.env.region}.amazonaws.com`
 
 describe('createItem function', () => {
   it('should respond with statusCode 200 to correct request', async () => {
@@ -12,10 +10,16 @@ describe('createItem function', () => {
     }
 
     // WHEN
-    const actual = await axios.post('/item', payload)
+    const response = await fetch(`${baseURL}/item`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: {
+        "Content-Type": "application/json",
+      }
+    })
 
     // THEN
-    expect(actual.status).toBe(200)
+    expect(response.status).toBe(200)
   })
 
   it('should respond with Bad Request 400 to incorrect request', async () => {
@@ -23,16 +27,16 @@ describe('createItem function', () => {
     const wrongPayload = {}
 
     // WHEN
-    let actual
-    try {
-      await axios.post('/item', wrongPayload)
-    } catch (e) {
-      actual = e.response
-    }
+    const response = await fetch(`${baseURL}/item`, {
+      method: 'POST',
+      body: JSON.stringify(wrongPayload),
+      headers: {
+        "Content-Type": "application/json",
+      }
+    })
 
     // THEN
-    expect(actual.status).toBe(400)
-    expect(actual.statusText).toBe('Bad Request')
+    expect(response.status).toBe(400)
   })
 
   it('should respond with Not implemented yet for other methods than add', async () => {
@@ -44,16 +48,17 @@ describe('createItem function', () => {
     }
 
     // WHEN
-    let actual
-    try {
-      await axios.post('/item', payload)
-    } catch (e) {
-      actual = e.response
-    }
+    const response = await fetch(`${baseURL}/item`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: {
+        "Content-Type": "application/json",
+      }
+    })
+    const text = await response.text()
 
     // THEN
-    expect(actual.status).toBe(400)
-    expect(actual.statusText).toBe('Bad Request')
-    expect(actual.data).toBe('Not implemented yet!')
+    expect(response.status).toBe(400)
+    expect(text).toEqual('Not implemented yet!')
   })
 })

--- a/__tests__/processItem/functionIsTriggeredByDdbStream.e2e.mjs
+++ b/__tests__/processItem/functionIsTriggeredByDdbStream.e2e.mjs
@@ -1,6 +1,4 @@
-import axios from 'axios'
-
-axios.defaults.baseURL = `https://${process.env.httpApiGatewayEndpointId}.execute-api.${process.env.region}.amazonaws.com`
+const baseURL = `https://${process.env.httpApiGatewayEndpointId}.execute-api.${process.env.region}.amazonaws.com`
 
 describe('processItem Lambda function', () => {
   it('should be invoked by DDB Stream after createItem Lambda saves element into DynamoDB', async () => {
@@ -12,11 +10,18 @@ describe('processItem Lambda function', () => {
     }
 
     // WHEN
-    const actual = await axios.post('/item', payload)
-    const newItemDbId = actual.data.id
+    const response = await fetch(`${baseURL}/item`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: {
+            "Content-Type": "application/json",
+        }
+    })
+    const actual = await response.json()
+    const newItemDbId = actual.id
 
     // THEN
-    expect(actual.status).toBe(200)
+    expect(response.status).toBe(200)
 
     // Using aws-testing-library lib that extends jest framework
     await expect({

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@aws-sdk/lib-dynamodb": "^3.465.0",
         "@types/jest": "^29.5.11",
         "aws-testing-library": "gerwant/aws-testing-library#modernization",
-        "axios": "^1.6.2",
         "dotenv": "^16.0.1",
         "eslint": "^8.55.0",
         "eslint-config-airbnb-base": "^15.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@aws-lambda-powertools/logger": "^1.17.0",
         "@middy/core": "^5.1.0",
         "@middy/http-error-handler": "^5.1.0",
         "@middy/http-json-body-parser": "^5.1.0",
@@ -194,6 +195,28 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/@aws-lambda-powertools/commons": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.17.0.tgz",
+      "integrity": "sha512-eZbOUGKH+oNG49oObXucffTdUyj0XmQTnddgDWmSWLgAQ4/L60n7x80hYOTCmDqATxPoA4ADa+fzAxGx0hyaxQ=="
+    },
+    "node_modules/@aws-lambda-powertools/logger": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.17.0.tgz",
+      "integrity": "sha512-HdesKvINDebLsxEyLzjEvn4ZiO3lYnl9Ol7GuRGgSTsB4byEeRbhAghCGCPZb0CA/NaDVQleaLTTjjsJjm6I7A==",
+      "dependencies": {
+        "@aws-lambda-powertools/commons": "^1.17.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "peerDependencies": {
+        "@middy/core": ">=3.x"
+      },
+      "peerDependenciesMeta": {
+        "@middy/core": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@aws-sdk/client-cloudformation": {
       "version": "3.481.0",
@@ -9212,8 +9235,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@aws-sdk/lib-dynamodb": "^3.465.0",
     "@types/jest": "^29.5.11",
     "aws-testing-library": "gerwant/aws-testing-library#modernization",
-    "axios": "^1.6.2",
     "dotenv": "^16.0.1",
     "eslint": "^8.55.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "serverless-iam-test-helper": "^0.0.4"
   },
   "dependencies": {
+    "@aws-lambda-powertools/logger": "^1.17.0",
     "@middy/core": "^5.1.0",
     "@middy/http-error-handler": "^5.1.0",
     "@middy/http-json-body-parser": "^5.1.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,6 +18,7 @@ provider:
     stage: ${self:provider.stage}
     region: ${self:provider.region}
     service: ${self:service}
+    POWERTOOLS_SERVICE_NAME: ${self:service}
     # your variables - optional
     httpApiGatewayEndpointId: !Ref HttpApi
   tags:

--- a/src/common/adapters/DynamoDbAdapter.mjs
+++ b/src/common/adapters/DynamoDbAdapter.mjs
@@ -3,6 +3,9 @@ import {
   DeleteItemCommand, DynamoDBClient
 } from '@aws-sdk/client-dynamodb';
 import { QueryCommand, DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { Logger } from '@aws-lambda-powertools/logger'
+
+const logger = new Logger()
 
 export class DynamoDbAdapter {
   constructor() {
@@ -50,7 +53,10 @@ export class DynamoDbAdapter {
   }
 
   async createItem(tableName, entity) {
-    console.log(`Saving new item id="${entity.id}" into DynamoDB table ${tableName}`)
+    logger.info('Saving new item into DynamoDB Table', {
+      itemId: entity.id,
+      tableName,
+    })
     const params = {
       Item: entity.toItem(),
       ReturnConsumedCapacity: 'TOTAL',
@@ -58,10 +64,10 @@ export class DynamoDbAdapter {
     }
     try {
       await this.create(params)
-      console.log('Item saved successfully')
+      logger.info('Item saved successfully')
       return entity
     } catch (error) {
-      console.log('Error', error)
+      logger.info('Error', error)
       throw error
     }
   }
@@ -71,7 +77,11 @@ export class DynamoDbAdapter {
   }
 
   async delete(params) {
-    console.log(`Deleting item with PK = ${params.Key.PK.S} & SK = ${params.Key.SK ? params.Key.SK.S : 'not present'}`)
+    logger.info('Deleting item', {
+      PK: params.Key.PK.S,
+      SK: params.Key.SK ? params.Key.SK.S : 'not present',
+      tableName: params.TableName,
+    })
     return this.client.send(new DeleteItemCommand(params))
   }
 

--- a/src/common/services/MyEntityService.mjs
+++ b/src/common/services/MyEntityService.mjs
@@ -1,5 +1,9 @@
+import { Logger } from '@aws-lambda-powertools/logger'
+
 import { DynamoDbAdapter } from '../adapters/DynamoDbAdapter.mjs';
 import { MyEntity } from '../entities/MyEntity.mjs'
+
+const logger = new Logger()
 
 export class MyEntityService {
   constructor(dynamoDbAdapter) {
@@ -8,7 +12,7 @@ export class MyEntityService {
   }
 
   async create(result) {
-    console.log('Creating MyEntity item in repository')
+    logger.info('Creating MyEntity item in repository')
     const myEntity = new MyEntity({ result })
     await this.dynamoDbAdapter.createItem(this.tableName, myEntity)
     return myEntity

--- a/src/createItem/businessLogic.mjs
+++ b/src/createItem/businessLogic.mjs
@@ -1,5 +1,15 @@
+import { Logger } from '@aws-lambda-powertools/logger'
+
+const logger = new Logger()
+
 export const performCalculation = ({ a, b, method }) => {
-  console.log(`Received method="${method}" and values: a=${a}; b=${b}`)
+  logger.info('Received method with values', {
+    method,
+    values: {
+      a,
+      b,
+    }
+  })
   switch (method) {
     case 'add':
       return a + b

--- a/src/createItem/function.mjs
+++ b/src/createItem/function.mjs
@@ -37,5 +37,5 @@ export const handler = middy()
   .use(validatorMiddleware({
     eventSchema: transpileSchema(inputSchema)
   }))
-  .use(httpErrorHandler({ logger: (...args) => logger.error(args)}))
+  .use(httpErrorHandler({ logger: (...args) => logger.error(args) }))
   .handler(lambdaHandler)

--- a/src/createItem/function.mjs
+++ b/src/createItem/function.mjs
@@ -3,11 +3,15 @@ import jsonBodyParser from '@middy/http-json-body-parser'
 import httpErrorHandler from '@middy/http-error-handler'
 import validatorMiddleware from '@middy/validator'
 import { transpileSchema } from '@middy/validator/transpile'
+import { Logger } from '@aws-lambda-powertools/logger'
+
 import { performCalculation } from './businessLogic.mjs'
 import { MyEntityService } from '../common/services/MyEntityService.mjs'
 
+const logger = new Logger()
+
 const lambdaHandler = async (event) => {
-  console.log('Starting Lambda function')
+  logger.info('Starting Lambda function')
   const result = performCalculation(event.body)
   const myEntityService = new MyEntityService()
   return myEntityService.create(result)
@@ -33,5 +37,5 @@ export const handler = middy()
   .use(validatorMiddleware({
     eventSchema: transpileSchema(inputSchema)
   }))
-  .use(httpErrorHandler())
+  .use(httpErrorHandler({ logger: (...args) => logger.error(args)}))
   .handler(lambdaHandler)

--- a/src/processItem/function.mjs
+++ b/src/processItem/function.mjs
@@ -1,10 +1,14 @@
+import { Logger } from '@aws-lambda-powertools/logger'
+
+const logger = new Logger()
+
 export const handler = async (event) => {
   const item = parseEvent(event)
-  console.log('item', JSON.stringify(item))
+  logger.info('Received item to process', { item })
 
   // this log message is used for testing
   // don't remove it. See: functionIsTriggeredByDdbStream.e2e.js
-  console.log(`Processing item ${item.dynamodb.Keys.PK.S}`)
+  logger.info(`Processing item ${item.dynamodb.Keys.PK.S}`)
 
   // here you can implement rest of your Lambda code
 


### PR DESCRIPTION
A few small changes:

1. Introduced `Logger` from `aws-lambda-powertools` for TS/JS to replace use of `console.log`
2. Replace `axios` with native `fetch` within tests