### PR TITLE
feat: Add direct deployment method 

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -13,6 +13,7 @@ provider:
   runtime: nodejs20.x
   region: ${opt:region, self:custom.deployment.region.${self:custom.globalStage}}
   logRetentionInDays: 60 # how long logs are kept in CloudWatch
+  deploymentMethod: direct
   environment:
     # required Environment Variables. Don't remove.
     stage: ${self:provider.stage}


### PR DESCRIPTION
By default in v3 Framework uses changeset-based updates which are much slower than direct CloudFormation updates